### PR TITLE
refactor(file): 移除 AirConfig 中的 fileEntityClass 配置项

### DIFF
--- a/component/Image.vue
+++ b/component/Image.vue
@@ -1,9 +1,10 @@
 <script generic="F extends IFile" lang="ts" setup>
 import type { PropType } from 'vue'
 import type { IFile } from '../interface/IFile'
-
 import type { IJson } from '../interface/IJson'
+
 import type { ClassConstructor } from '../type/AirType'
+import { AirFileEntity } from '@airpower/model/entity/AirFileEntity'
 import { CircleCloseFilled } from '@element-plus/icons-vue'
 import { computed, ref, watch } from 'vue'
 import { AirConfig } from '../config/AirConfig'
@@ -127,7 +128,7 @@ const props = defineProps({
    */
   entity: {
     type: Function as unknown as PropType<ClassConstructor<F>>,
-    default: AirConfig.fileEntityClass,
+    default: AirFileEntity,
   },
 })
 

--- a/component/ToolBar.vue
+++ b/component/ToolBar.vue
@@ -6,7 +6,7 @@ import type { IFile } from '../interface/IFile'
 import type { IJson } from '../interface/IJson'
 import type { AirRequest } from '../model/AirRequest'
 import type { ClassConstructor } from '../type/AirType'
-
+import { AirFileEntity } from '@airpower/model/entity/AirFileEntity'
 import { ElOption } from 'element-plus'
 import { computed, ref } from 'vue'
 import { AirEntity } from '../base/AirEntity'
@@ -160,11 +160,10 @@ const props = defineProps({
 
   /**
    * # 导入的文件实体类
-   * 可通过 `AirConfig.fileEntityClass` 配置, 默认为 `AirFileEntity`
    */
   fileEntity: {
     type: Function as unknown as PropType<ClassConstructor<IFile>>,
-    default: AirConfig.fileEntityClass,
+    default: AirFileEntity,
   },
 
   /**
@@ -377,6 +376,10 @@ async function onImport() {
     url = `${service.baseUrl}/${AirConfig.importUrl}`
     url = getApiUrl(url)
   }
+  if (!props.fileEntity) {
+    await AirNotification.error('请为ToolBar传入fileEntity', '导入失败')
+    return
+  }
   await AirDialog.showUpload(
     {
       uploadUrl: url,
@@ -384,7 +387,7 @@ async function onImport() {
       title: props.importTitle || AirI18n.get().Import || '导入',
       uploadSuccess: AirI18n.get().ImportSuccess || '数据导入成功',
       confirmText: AirI18n.get().DownloadTemplate || '下载模板',
-      entity: AirConfig.fileEntityClass,
+      entity: props.fileEntity,
     },
     () => {
       onDownloadTemplate()

--- a/component/Upload.vue
+++ b/component/Upload.vue
@@ -3,6 +3,7 @@ import type { PropType } from 'vue'
 import type { IFile } from '../interface/IFile'
 import type { IJson } from '../interface/IJson'
 import type { ClassConstructor } from '../type/AirType'
+import { AirFileEntity } from '@airpower/model/entity/AirFileEntity'
 import { computed, ref } from 'vue'
 import { ADialog } from '.'
 import { AirConfig } from '../config/AirConfig'
@@ -107,7 +108,7 @@ const props = defineProps({
    */
   entity: {
     type: Function as unknown as PropType<ClassConstructor<F>>,
-    default: AirConfig.fileEntityClass,
+    default: AirFileEntity,
   },
 
   /**

--- a/config/AirConfig.ts
+++ b/config/AirConfig.ts
@@ -1,8 +1,6 @@
-import type { IFile } from '../interface/IFile'
 import type { ITreeProps } from '../interface/props/ITreeProps'
-import type { AirMoneyDirection, ClassConstructor } from '../type/AirType'
+import type { AirMoneyDirection } from '../type/AirType'
 import { AirDateTimeFormatter } from '../enum/AirDateTimeFormatter'
-import { AirFileEntity } from '../model/entity/AirFileEntity'
 import { AirApi } from './AirApi'
 import { AirConstant } from './AirConstant'
 
@@ -202,11 +200,6 @@ export class AirConfig {
    * `默认true` 此项仅为默认, 如在装饰器中配置, 此项将无效
    */
   static showLengthLimitTextarea = true
-
-  /**
-   * ### 默认的文件实现类
-   */
-  static fileEntityClass: ClassConstructor<IFile> = AirFileEntity
 
   /**
    * ### `ESC` 是否可关闭掉所有的弹窗

--- a/helper/AirDialog.ts
+++ b/helper/AirDialog.ts
@@ -1,3 +1,4 @@
+import type { AirFileEntity } from '@airpower/model/entity/AirFileEntity'
 import type { App, Component } from 'vue'
 import type { AirEntity } from '../base/AirEntity'
 import type { IFile } from '../interface/IFile'
@@ -117,7 +118,7 @@ export class AirDialog {
    * @param config `可选` 上传自定义配置
    * @param customConfirm `可选` 自定义确认按钮回调方法
    */
-  static async showUpload<F extends IFile>(config?: IUploadProps, customConfirm?: () => void): Promise<F> {
+  static async showUpload<F extends IFile = AirFileEntity>(config?: IUploadProps<F>, customConfirm?: () => void): Promise<F> {
     return this.build<F>(AUpload, {
       onCustomConfirm: () => {
         if (customConfirm) {

--- a/interface/props/IUploadProps.ts
+++ b/interface/props/IUploadProps.ts
@@ -1,3 +1,4 @@
+import type { AirFileEntity } from '@airpower/model/entity/AirFileEntity'
 import type { ClassConstructor } from '../../type/AirType'
 import type { IFile } from '../IFile'
 import type { IJson } from '../IJson'
@@ -6,7 +7,7 @@ import type { IJson } from '../IJson'
  * # 上传配置项
  * @author Hamm.cn
  */
-export interface IUploadProps {
+export interface IUploadProps<F extends IFile = AirFileEntity> {
   /**
    * ### 对话框标题
    */
@@ -48,7 +49,7 @@ export interface IUploadProps {
    * ### 上传文件的接收实体类
    * 可通过 `AirConfig.defaultFileEntity` 配置, 默认为 `AirFileEntity`
    */
-  entity?: ClassConstructor<IFile>
+  entity?: ClassConstructor<F>
 
   /**
    * ### 自定义上传成功的回调


### PR DESCRIPTION
- 删除了 AirConfig 中的 fileEntityClass 静态属性
- 更新了 AirDialog、image 组件、IUploadProps 接口中对文件实体类的引用
- 改为直接使用 AirFileEntity 作为默认的文件实体类