### PR TITLE
refactor(permission): 重构权限处理逻辑

### DIFF
--- a/config/AirConfig.ts
+++ b/config/AirConfig.ts
@@ -123,11 +123,7 @@ export class AirConfig {
   static errorMessage = '系统发生了一些错误，请稍候再试 :)'
 
   /**
-   * ### 是否自动处理常用权限
-   *
-   * 如此项配置为 `false` , 则 `EntityConfig` 中的 `permissionPrefix` 将自动失效
-   *
-   * 若此时 `EntityConfig` 没有配置其他的权限标识, 则认为不校验权限
+   * ### 是否自动处理权限前缀
    */
   static autoPermission = true
 

--- a/interface/decorators/IModelConfig.ts
+++ b/interface/decorators/IModelConfig.ts
@@ -27,87 +27,62 @@ export interface IModelConfig {
 
   /**
    * ### 添加权限标识
-   * 如 `AToolBar` 传入 `addPermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   addPermission?: string
 
   /**
    * ### 导出权限标识
-   * 如 `AToolBar` 传入 `exportPermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   exportPermission?: string
 
   /**
    * ### 导入权限标识
-   * 如 `AToolBar` 传入 `importPermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   importPermission?: string
 
   /**
    * ### 表格的没有数据时的提示文本
-   *  如 `ATable` 传入 `emptyText` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   tableEmptyText?: string
 
   /**
    * ### 编辑权限标识
-   * 如 `ATable` 传入 `editPermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   editPermission?: string
 
   /**
    * ### 详情权限标识
-   * 如 `ATable` 传入 `detailPermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   detailPermission?: string
 
   /**
    * ### 删除权限标识
-   * 如 `ATable` 传入 `deletePermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   deletePermission?: string
 
   /**
    * ### 添加子项目权限标识
-   * 如 `ATable` 传入 `addPermission` , 则此项失效，否则:
-   * - 如同时传入 `permissionPrefix`, 则会在此项前面加上 `permissionPrefix` 的配置
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
    */
   addChildPermission?: string
+
+  /**
+   * ### 禁用权限标识
+   */
+  disablePermission?: string
+
+  /**
+   * ### 启用权限标识
+   */
+  enablePermission?: string
+
+  /**
+   * ### 权限标识前缀
+   */
+  permissionPrefix?: string
 
   /**
    * ### 全局隐藏字段列选择器
    * 如设置 `true`, 则 `ATable` 传入的 `hideFieldSelector` 失效
    */
   hideFieldSelector?: boolean
-
-  /**
-   * ### 权限标识前缀
-   * 如指定了此项,则当前配置装饰器中不再需要手动写前缀
-   *
-   * - 如配置 `AirConfig.autoPermission=false`, 则传入 `permissionPrefix` 失效
-   */
-  permissionPrefix?: string
 }


### PR DESCRIPTION
- 修改 AirConfig 中 autoPermission 的含义，更名为 autoPermissionPrefix
- 重构 AirPermission 类中的权限获取逻辑，简化代码结构
- 更新 IModelConfig接口，移除冗余注释